### PR TITLE
add functional header for std::invoke

### DIFF
--- a/include/draft/util/TaskPool.hh
+++ b/include/draft/util/TaskPool.hh
@@ -27,6 +27,7 @@
 #ifndef __DRAFT_UTIL_TASK_POOL_HH__
 #define __DRAFT_UTIL_TASK_POOL_HH__
 
+#include <functional>
 #include <future>
 #include <memory>
 #include <thread>


### PR DESCRIPTION
Fixes build error:

```
In file included from /draft/src/util/TaskPool.cc:27:
/draft/include/draft/util/TaskPool.hh: In lambda function:
/draft/include/draft/util/TaskPool.hh:79:39: error: 'invoke' is not a member of 'std'
    79 |                     p->set_value(std::invoke(std::move(f), stopToken, std::forward<Args>(args)...));
       |                                       ^~~~~~
/draft/include/draft/util/TaskPool.hh:37:1: note: 'std::invoke' is defined in header '<functional>'; did you forget to '#include <functional>'?
  36 | #include "Util.hh"
 +++ |+#include <functional>
```